### PR TITLE
Update FAQ.md | add missing Containers in the see logs section and also added the missing commands

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -30,7 +30,6 @@ At the time of writing this FAQs the known containers for Venho applications are
 - ipfs
 - redis
 - qdrant
-- storage
 
 In order to see the logs nerdctl can be used running the following command:
 

--- a/FAQ.md
+++ b/FAQ.md
@@ -26,10 +26,20 @@ At the time of writing this FAQs the known containers for Venho applications are
 - storage
 - processor
 - venho-ada-frontend-httpd-1
+- ollama
+- ipfs
+- redis
+- qdrant
+- storage
 
 In order to see the logs nerdctl can be used running the following command:
 
 ```
+# Switch to root
+devel-su
+# Switch to venho-ada-env enviorment
+venho-ada-env
+
 # See logs for all containers:
 nerdctl compose logs -f
 # See logs for a specific container (e.g., processor):


### PR DESCRIPTION
added missing containers to list in the see logs section.
added also the instructions in the comand section on how to switch to the venho-ada-env enviorment, to be able to run the commands below.